### PR TITLE
feat: cancel button moved to the framework level

### DIFF
--- a/src/main/kotlin/net/transgene/mylittlebudget/tg/bot/framework/Action.kt
+++ b/src/main/kotlin/net/transgene/mylittlebudget/tg/bot/framework/Action.kt
@@ -1,0 +1,99 @@
+package net.transgene.mylittlebudget.tg.bot.framework
+
+import com.github.kotlintelegrambot.entities.InlineKeyboardButton
+import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
+import com.google.gson.JsonSyntaxException
+
+interface Action {
+    fun perform(conversation: Conversation)
+}
+
+class SendMessage(private val text: String, private val buttons: List<Button<out Any>>? = null, private val cancellable: Boolean = true) : Action {
+    override fun perform(conversation: Conversation) {
+        val (res, ex) = conversation.bot.sendMessage(
+            chatId = conversation.chatId,
+            text = text,
+            replyMarkup = InlineKeyboardMarkup(getButtons(conversation, buttons, cancellable))
+        )
+        if (ex != null) {
+            throw ActionException(ex)
+        } else {
+            val messageId = res?.body()?.result?.messageId ?: throw ActionException("MessageId not found in response")
+            conversation.logMessage(messageId)
+        }
+    }
+}
+
+class EditMessage(private val messageId: Long, private val text: String, private val buttons: List<Button<out Any>>? = null, private val cancellable: Boolean = true) :
+    Action {
+    override fun perform(conversation: Conversation) {
+        val (_, ex) = conversation.bot.editMessageText(
+            chatId = conversation.chatId,
+            messageId = messageId,
+            text = text,
+            replyMarkup = InlineKeyboardMarkup(getButtons(conversation, buttons, cancellable))
+        )
+        if (ex != null) {
+            throw ActionException(ex)
+        }
+    }
+}
+
+class DeleteMessage(private val messageId: Long) : Action {
+    override fun perform(conversation: Conversation) {
+        val (_, ex) = conversation.bot.deleteMessage(chatId = conversation.chatId, messageId = messageId)
+        if (ex != null) {
+            throw ActionException(ex)
+        }
+    }
+}
+
+object Finish : Action {
+    override fun perform(conversation: Conversation) {
+        val messages = conversation.getMessages().dropLast(1)
+        finishConversation(messages, conversation)
+    }
+
+}
+
+object Cancel : Action {
+    override fun perform(conversation: Conversation) {
+        val messages = conversation.getMessages()
+        finishConversation(messages, conversation)
+    }
+}
+
+data class Button<P>(val text: String, val payload: P)
+
+class ActionException : RuntimeException {
+    constructor(cause: Exception) : super(cause)
+    constructor(message: String) : super(message)
+}
+
+private fun finishConversation(messages: List<Long>, conversation: Conversation) {
+    messages.forEach {
+        val (_, ex) = conversation.bot.deleteMessage(chatId = conversation.chatId, messageId = it)
+        if (ex != null
+            //FIXME Find the cause of the JsonSyntaxException (#11)
+            && !(ex is JsonSyntaxException && ex.message?.startsWith("java.lang.IllegalStateException: Expected BEGIN_OBJECT but was BOOLEAN", true) == true)) {
+            //TODO Do not throw the error to the user. Log instead, try to delete as many messages as possible and finish the conversation anyway (#7)
+            throw ActionException(ex)
+        }
+    }
+    conversation.finish()
+}
+
+private fun createButton(conversation: Conversation, text: String, payload: Any): List<InlineKeyboardButton> {
+    val buttonId = conversation.addButtonPayload(payload)
+    return listOf(InlineKeyboardButton(text = text, callbackData = "${conversation.id}#$buttonId"))
+}
+
+private fun getButtons(conversation: Conversation, userButtons: List<Button<out Any>>?, addCancelButton: Boolean): List<List<InlineKeyboardButton>> {
+    val buttons = userButtons?.map { createButton(conversation, it.text, it.payload) }?.toMutableList()
+        ?: mutableListOf()
+
+    if (addCancelButton) {
+        buttons.add(createButton(conversation, "[Отменить]", Cancel))
+    }
+    return buttons
+}

--- a/src/main/kotlin/net/transgene/mylittlebudget/tg/bot/framework/Command.kt
+++ b/src/main/kotlin/net/transgene/mylittlebudget/tg/bot/framework/Command.kt
@@ -1,11 +1,5 @@
 package net.transgene.mylittlebudget.tg.bot.framework
 
-import com.github.kotlintelegrambot.Bot
-import com.github.kotlintelegrambot.entities.InlineKeyboardButton
-import com.github.kotlintelegrambot.entities.InlineKeyboardMarkup
-import java.util.*
-import kotlin.collections.LinkedHashMap
-
 interface Command {
     fun call(callMessageId: Long): List<Action>
 }
@@ -18,81 +12,8 @@ interface ButtonPressCommand<P> : Command {
     fun consumeButtonPress(messageId: Long, payload: P): List<Action>
 }
 
-class Conversation(val command: Command, val chatId: Long, val bot: Bot) {
-    val id = UUID.randomUUID().toString()
-
-    private val buttonPayloads: LinkedHashMap<Int, Any> = LinkedHashMap()
-
-    fun getButtonPayloadById(id: Int): Any? {
-        return buttonPayloads[id]
-    }
-
-    fun addButtonPayload(payload: Any): Int {
-        val buttonId = nextButtonId()
-        buttonPayloads[buttonId] = payload
-        return buttonId
-    }
-
-    private fun nextButtonId(): Int {
-        return if (buttonPayloads.isEmpty()) {
-            Int.MIN_VALUE
-        } else {
-            val maxId = buttonPayloads.keys.last()
-            if (maxId == Int.MAX_VALUE) {
-                throw IllegalStateException("Button payloads registry overflown during the conversation")
-            }
-            maxId + 1
-        }
-    }
-}
-
 data class CallbackPayload(
     val conversationId: String,
     val buttonId: Int
 )
 
-interface Action {
-    fun perform(conversation: Conversation)
-}
-
-class SendMessage(private val text: String, private val buttons: List<Button<out Any>>? = null): Action {
-    override fun perform(conversation: Conversation) {
-        val kbButtons = buttons?.map {
-            val buttonId = conversation.addButtonPayload(it.payload)
-            listOf(InlineKeyboardButton(text = it.text, callbackData = "${conversation.id}#$buttonId"))
-        }
-        conversation.bot.sendMessage(
-            chatId = conversation.chatId,
-            text = text,
-            replyMarkup = kbButtons?.let { InlineKeyboardMarkup(it) }
-        )
-    }
-}
-
-class EditMessage(private val messageId: Long, private val text: String, private val buttons: List<Button<out Any>>?) :
-    Action {
-    override fun perform(conversation: Conversation) {
-        val kbButtons: List<List<InlineKeyboardButton>>? = buttons?.map {
-            val buttonId = conversation.addButtonPayload(it.payload)
-            listOf(InlineKeyboardButton(text = it.text, callbackData = "${conversation.id}#$buttonId"))
-        }
-        conversation.bot.editMessageText(
-            chatId = conversation.chatId,
-            messageId = messageId,
-            text = text,
-            replyMarkup = kbButtons?.let { InlineKeyboardMarkup(it) }
-        )
-    }
-}
-
-class DeleteMessage(private val messageId: Long): Action {
-    override fun perform(conversation: Conversation) {
-        conversation.bot.deleteMessage(chatId = conversation.chatId, messageId = messageId)
-    }
-}
-
-object Finish: Action {
-    override fun perform(conversation: Conversation) {}
-}
-
-data class Button<P>(val text: String, val payload: P)

--- a/src/main/kotlin/net/transgene/mylittlebudget/tg/bot/framework/Conversation.kt
+++ b/src/main/kotlin/net/transgene/mylittlebudget/tg/bot/framework/Conversation.kt
@@ -1,0 +1,72 @@
+package net.transgene.mylittlebudget.tg.bot.framework
+
+import com.github.kotlintelegrambot.Bot
+import java.util.*
+import kotlin.collections.ArrayList
+import kotlin.collections.LinkedHashMap
+
+class Conversation(command: Command, bot: Bot, val chatId: Long, initialMessageId: Long) {
+    private var finished: Boolean = false
+    private val buttonPayloads: LinkedHashMap<Int, Any> = LinkedHashMap()
+    private val messages: MutableList<Long> = ArrayList()
+
+    init {
+        messages.add(initialMessageId)
+    }
+
+    val id = UUID.randomUUID().toString()
+
+    val bot: Bot = bot
+        get() {
+            checkFinished()
+            return field
+        }
+
+    val command: Command = command
+        get() {
+            checkFinished()
+            return field
+        }
+
+    fun getButtonPayloadById(id: Int): Any? = buttonPayloads[id]
+
+    fun addButtonPayload(payload: Any): Int {
+        checkFinished()
+        val buttonId = nextButtonId()
+        buttonPayloads[buttonId] = payload
+        return buttonId
+    }
+
+    fun getMessages(): List<Long> = ArrayList(messages)
+
+    fun logMessage(messageId: Long) {
+        checkFinished()
+        messages.add(messageId)
+    }
+
+    fun finish() {
+        finished = true
+    }
+
+    fun isFinished(): Boolean {
+        return finished
+    }
+
+    private fun checkFinished() {
+        if (finished) {
+            throw IllegalStateException("Conversation has already finished")
+        }
+    }
+
+    private fun nextButtonId(): Int {
+        return if (buttonPayloads.isEmpty()) {
+            Int.MIN_VALUE
+        } else {
+            val maxId = buttonPayloads.keys.last()
+            if (maxId == Int.MAX_VALUE) {
+                throw IllegalStateException("Button payloads registry overflown during the conversation")
+            }
+            maxId + 1
+        }
+    }
+}


### PR DESCRIPTION
Every message from the bot now has "Cancel" button, allowing to cancel
 the flow of the current operation and delete all messages that were
 produced during its execution.
Messages (except the last one) are now deleted on the successful
 completion of the conversation.

 Closes: #3, #8, #9